### PR TITLE
Update LabProcess_v0.1-DRAFT.jsonld

### DIFF
--- a/LabProcess/jsonld/type/LabProcess_v0.1-DRAFT.jsonld
+++ b/LabProcess/jsonld/type/LabProcess_v0.1-DRAFT.jsonld
@@ -15,21 +15,6 @@
       "rdfs:subClassOf": {
         "@id": "schema:Action"
       },
-      "$validation": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "type": "object",
-        "properties": {
-          "parameterValue": {
-            "description": "A parameter value of the experimental process, usually a key-value pair using ontology terms."
-          },
-          "executesLabProtocol": {
-            "description": "The protocol describes the experimental workflow and its parameters, which is instanciated by this process."
-          }
-        },
-        "required": [],
-        "recommended": [],
-        "optional": []
-      },
       "schemaVersion": [
         "https://schema.org/docs/releases.html#v23.0"
       ]
@@ -39,7 +24,9 @@
       "@type": "rdf:Property",
       "rdfs:comment": "A parameter value of the experimental process, usually a key-value pair using ontology terms.",
       "rdfs:label": "parameterValue",
-      "schema:domainIncludes": "isa:LabProcess",
+      "schema:domainIncludes": {
+        "@id":"isa:LabProcess"
+      },
       "schema:rangeIncludes": [
         {
           "@id": "schema:PropertyValue"
@@ -51,7 +38,9 @@
       "@type": "rdf:Property",
       "rdfs:comment": "The protocol describes the experimental workflow and its parameters, which is instanciated by this process.",
       "rdfs:label": "executesLabProtocol",
-      "schema:domainIncludes": "isa:LabProcess",
+      "schema:domainIncludes": {
+        "@id": "isa:LabProcess"
+      },
       "schema:rangeIncludes": [
         {
           "@id": "bioschemastypesdrafts:LabProtocol"


### PR DESCRIPTION
removed validation since Types don't have the constraints that are imposed by validation. Fixed formatting of domainIncludes.
