### PR TITLE
small suggestion and fix typo

### DIFF
--- a/LabProcess/jsonld/type/LabProcess_v0.1-DRAFT.jsonld
+++ b/LabProcess/jsonld/type/LabProcess_v0.1-DRAFT.jsonld
@@ -23,7 +23,7 @@
             "description": "A parameter value of the experimental process, usually a key-value pair using ontology terms."
           },
           "executesLabProtocol": {
-            "description": "The protocol describes the experimental workflow and its parameters, which is instanciated by this process."
+            "description": "The lab protocol describes the experimental workflow and its parameters, which is instantiated by this process."
           }
         },
         "required": [],
@@ -49,7 +49,7 @@
     {
       "@id": "isa:executesLabProtocol",
       "@type": "rdf:Property",
-      "rdfs:comment": "The protocol describes the experimental workflow and its parameters, which is instanciated by this process.",
+      "rdfs:comment": "The lab protocol describes the experimental workflow and its parameters, which is instantiated by this process.",
       "rdfs:label": "executesLabProtocol",
       "schema:domainIncludes": "isa:LabProcess",
       "schema:rangeIncludes": [


### PR DESCRIPTION
- The context link to ISA line 6 is dead ("isa": "https://discovery.biothings.io/view/isa/").

The description here "A LabProcess represents the specific application of a LabProtocol" deviates from the email discussion "The LabProcess type functions as a parameterized, specific instance/execution of a laboratory **process**, using specific inputs and producing specific outputs.". I assume in the latter you meant protocol? 